### PR TITLE
add sugarcane model to bonsai pot

### DIFF
--- a/src/config/bonsaitrees/shapes.d/minecraft_reeds001.json
+++ b/src/config/bonsaitrees/shapes.d/minecraft_reeds001.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:reeds",
+  "version": 2,
+  "ref": {
+    "a": {
+      "name": "minecraft:reeds",
+      "meta": 0
+    }
+  },
+  "shape": [
+    [
+      "a",
+      "a",
+      "a"
+    ]
+  ]
+}


### PR DESCRIPTION
sugar cane currently shows no model even when fully grown on bonsai pots