### PR TITLE
ATLauncher Readme link without www

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Beyond this initial release, we are planning regular content updates outside of 
 ## Downloads
 Released files:
 - [Curse/Twitch](https://minecraft.curseforge.com/projects/skyfactory-4)
-- [ATLauncher](https://www.atlauncher.com/pack/SkyFactory4)
+- [ATLauncher](https://atlauncher.com/pack/SkyFactory4)
 
 ## Development
 


### PR DESCRIPTION
At least for me, the link to ATLauncher in the README is broken. Should be fixed now. But please verify it's actually fixing anything - maybe it's just my firefox that isn't resolving the redirect properly.